### PR TITLE
Make run-command-run-method configurable per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ When using Helm, you can edit a command before running it by typing `C-u RET` in
 
 ## Optional configuration
 
-By default, commands are run in `compilation-mode`. See [Lightweight external command integration in Emacs via compilation mode](https://massimilianomirra.com/notes/lightweight-external-command-integration-in-emacs-via-compilation-mode/) for some notes on how to make the most of `compilation-mode`. Alternatively (and experimentally), commands can be run in `term-mode` plus `compilation-minor-mode`, especially useful for commands with rich output such as colors, progress bars, and screen refreshes, while preserving `compilation-mode` functionality. Set `run-command-run-method` to `term` and please comment on [issue #2](https://github.com/bard/emacs-run-command/issues/2) if you find issues.
+By default, commands are run in `compilation-mode`. See [Lightweight external command integration in Emacs via compilation mode](https://massimilianomirra.com/notes/lightweight-external-command-integration-in-emacs-via-compilation-mode/) for some notes on how to make the most of `compilation-mode`. Alternatively (and experimentally), commands can be run in `term-mode` plus `compilation-minor-mode`, especially useful for commands with rich output such as colors, progress bars, and screen refreshes, while preserving `compilation-mode` functionality. Set `run-command-run-method` to `term` and please comment on [issue #2](https://github.com/bard/emacs-run-command/issues/2) if you find issues. Run method can also be set per command using the `:run-method` property:
+
+```emacs-lisp
+(defun run-command-recipe-local ()
+  (list
+   (list :command-name "hello"
+         :command-line "echo hello"
+         :run-method 'term)))
+```
 
 The auto-completion framework is automatically detected. It can be set manually by customizing `run-command-completion-method`.
 

--- a/run-command.el
+++ b/run-command.el
@@ -160,12 +160,12 @@ said functions)."
 (defun run-command--run (command-spec)
   "Run `COMMAND-SPEC'.  Back end for helm and ivy actions."
   (cl-destructuring-bind
-      (&key command-name command-line scope-name working-dir &allow-other-keys)
+      (&key command-name command-line scope-name working-dir run-method &allow-other-keys)
       command-spec
     (let* ((buffer-name-base (format "%s[%s]" command-name scope-name))
            (buffer-name (format "*%s*" buffer-name-base))
            (default-directory working-dir))
-      (pcase run-command-run-method
+      (pcase (or run-method run-command-run-method)
         ('compile
          (let ((compilation-buffer-name-function (lambda (_name-of-mode) buffer-name)))
            (compile command-line)))
@@ -202,9 +202,9 @@ said functions)."
                                (cons (plist-get command-spec :display) command-spec))
                              command-specs)))
     (helm-build-sync-source (run-command--shorter-recipe-name-maybe command-recipe)
-      :action 'run-command--helm-action
-      :candidates candidates
-      :filtered-candidate-transformer '(helm-adaptive-sort))))
+                            :action 'run-command--helm-action
+                            :candidates candidates
+                            :filtered-candidate-transformer '(helm-adaptive-sort))))
 
 (defun run-command--helm-action (command-spec)
   "Execute `COMMAND-SPEC' from Helm."


### PR DESCRIPTION
This is an awesome package! I've found it useful to be able to have some of my commands run in compilation mode and others in term, so this adds a command list property to set that.