### PR TITLE
Add ability to edit Ivy commands with a prefix arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Or:
   :bind ("C-c c" . run-command)
 ```
 
-When using Helm, you can edit a command before running it by typing `C-u RET` instead of `RET`. (See [issue #1](https://github.com/bard/emacs-run-command/issues) if you can help bring that to Ivy.)
+You can edit a command before running it by typing `C-u RET` instead of `RET`.
 
 ## Optional configuration
 

--- a/run-command.el
+++ b/run-command.el
@@ -248,18 +248,19 @@ said functions)."
                       command-specs)))
           run-command-recipes))
 
-(defun run-command--ivy-action (selection &optional edit)
+(defun run-command--ivy-action (selection)
   "Execute `SELECTION' from Ivy."
   (let* ((command-spec (cdr selection))
          (command-line (plist-get command-spec :command-line))
-         (final-command-line (if (or edit ivy-current-prefix-arg)
+         (final-command-line (if ivy-current-prefix-arg
                                  (read-string "> " (concat command-line " "))
                                command-line)))
     (run-command--run (plist-put command-spec
                                  :command-line final-command-line))))
 
 (defun run-command--ivy-edit-action (selection)
-  (run-command--ivy-action selection t))
+  (let ((ivy-current-prefix-arg t))
+    (run-command--ivy-action selection)))
 
 (provide 'run-command)
 

--- a/run-command.el
+++ b/run-command.el
@@ -124,7 +124,9 @@ said functions)."
   (unless (window-minibuffer-p)
     (ivy-read "Command Name: "
               (run-command--ivy-targets)
-              :action 'run-command--ivy-action)))
+              :action '(1
+                        ("o" run-command--ivy-action "Run command")
+                        ("e" run-command--ivy-edit-action "Edit and run command")))))
 
 (defun run-command--generate-command-specs (command-recipe)
   "Execute `COMMAND-RECIPE' to generate command specs."
@@ -191,10 +193,11 @@ said functions)."
                      (interrupt-process proc)
                      (sit-for 1)
                      (delete-process proc))
-                 (error nil)))))
+                 (error nil))))
+           (with-current-buffer (get-buffer buffer-name)
+             (erase-buffer)))
          (with-current-buffer
-             (make-term buffer-name-base shell-file-name nil "-c" command-line)
-           (erase-buffer)
+             (make-term buffer-name-base shell-file-name nil "-c" (format "echo %s && %s" command-line command-line))
            (compilation-minor-mode)
            (run-command-term-minor-mode)
            (setq-local run-command-command-spec command-spec)
@@ -245,10 +248,18 @@ said functions)."
                       command-specs)))
           run-command-recipes))
 
-(defun run-command--ivy-action (selection)
+(defun run-command--ivy-action (selection &optional edit)
   "Execute `SELECTION' from Ivy."
-  (let ((command-spec (cdr selection)))
-    (run-command--run command-spec)))
+  (let* ((command-spec (cdr selection))
+         (command-line (plist-get command-spec :command-line))
+         (final-command-line (if (or edit ivy-current-prefix-arg)
+                                 (read-string "> " (concat command-line " "))
+                               command-line)))
+    (run-command--run (plist-put command-spec
+                                 :command-line final-command-line))))
+
+(defun run-command--ivy-edit-action (selection)
+  (run-command--ivy-action selection t))
 
 (provide 'run-command)
 


### PR DESCRIPTION
Hello again! This is an attempt to fix #1. It is doing basically the same as the Helm version - if you press `C-u` before selecting a command, it gives you the chance to edit the command before you run it. I also added this feature as an [Ivy action](https://oremacs.com/swiper/#actions), so you can invoke `(ivy-dispatching-done)` and press `e` to edit the command before you run it as well.

While I was testing this, I noticed a bug with the term-mode run method: it was calling `(erase-buffer)` after the term buffer had been created, so fast-running commands would just get their output erased immediately. The fix is to call `(erase-buffer)` before calling `(make-term)` if the buffer already exists. I also made the term-mode run method output the command line at the top of the buffer so you can see what command you are running.