### PR TITLE
Add autoload cookie to run-command

### DIFF
--- a/run-command.el
+++ b/run-command.el
@@ -97,6 +97,7 @@ command will be run in `default-directory'."
 
 ;;; User interface
 
+;;;###autoload
 (defun run-command ()
   "Pick a command from a context-dependent list, and run it.
 


### PR DESCRIPTION
## Summary

Add autoload cookie to allow users to have the command in their namespace without loading the package.

## Checklist

- [ ] CI passes
- [ ] Ready to review
- [ ] Ready to merge
