### PR TITLE
Use helm-make-source instead of helm-build-sync-source

### DIFF
--- a/run-command.el
+++ b/run-command.el
@@ -32,7 +32,7 @@
 ;;; Code:
 
 (declare-function helm "ext:helm")
-(declare-function helm-build-sync-source "ext:helm")
+(declare-function helm-make-source "ext:helm")
 (defvar helm-current-prefix-arg)
 
 (declare-function ivy-read "ext:ivy")
@@ -215,7 +215,8 @@ said functions)."
          (candidates (mapcar (lambda (command-spec)
                                (cons (plist-get command-spec :display) command-spec))
                              command-specs)))
-    (helm-build-sync-source (run-command--shorter-recipe-name-maybe command-recipe)
+    (helm-make-source (run-command--shorter-recipe-name-maybe command-recipe)
+        'helm-source-sync
       :action 'run-command--helm-action
       :candidates candidates
       :filtered-candidate-transformer '(helm-adaptive-sort))))


### PR DESCRIPTION
## Summary

`declare-function' doesn't work with macros. Unless Helm is required
at compile time, `run-command.el' won't have knowledge of the macro.

## Checklist

- [ ] CI passes
- [ ] Ready to review
- [ ] Ready to merge
