### PR TITLE
dev,fix: not ignore specs without :command-line with :lisp-function

### DIFF
--- a/run-command-core.el
+++ b/run-command-core.el
@@ -43,11 +43,15 @@
      (thread-last
       command-recipe (funcall)
       (seq-filter
-       (lambda (spec) (and spec (map-elt spec :command-line))))
+       #'run-command-core--normal-recipe-p)
       (seq-map
        (lambda (spec) (map-insert spec :recipe command-recipe)))
       (seq-map #'run-command--normalize-command-spec)))
    command-recipes))
+
+(defun run-command-core--normal-recipe-p (spec)
+  "Return non-nil, when a given SPEC recipe is a normal one."
+  (and spec (or (map-elt spec :command-line) (map-elt spec :lisp-function))))
 
 (defun run-command-core-run (command-spec)
   "Run COMMAND-SPEC.


### PR DESCRIPTION
## Summary

fix an error when write recipe which instead of usage `:command-line` use the `:lisp-function`.


I am writed some recipes on the `master` branch and they normally works, but on the `develop` version it isn't work

## Issue

for example I write the following recipe:

```elisp
(list
 :command-name "byte-recompile-directory"
 :lisp-function 'byte-recompile-directory)
```

I expect that when I call `run-command` I can select this recipe and run it, but now `run-command` view nothing