### PR TITLE
func: introduce the new empty runner

### DIFF
--- a/run-command-runner-nothing.el
+++ b/run-command-runner-nothing.el
@@ -1,0 +1,38 @@
+;;; run-command-runner-nothing.el --- runner which does nothing -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020-2023 Massimiliano Mirra
+
+;; Author: Massimiliano Mirra <hyperstruct@gmail.com>
+;; URL: https://github.com/bard/emacs-run-command
+
+;; This file is not part of GNU Emacs
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
+;; see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Runner for `run-command' based on `compilation-mode'.
+
+;;; Code:
+
+(require 'run-command-core)
+
+(defun run-command-runner-nothing (_line _buffer _output)
+  "Command runner for `run-command' which does nothing.")
+
+;;;; Meta
+
+(provide 'run-command-runner-nothing)
+
+;;; run-command-runner-nothing.el ends here


### PR DESCRIPTION
## Summary

I think it can be useful for some special cases, it with `:hook` can be awesome alternative to the `:lisp-function`, and very easy to maintenance

## Issue

Experiment `:lisp-function` is a retired one, so alternative to it should be created
